### PR TITLE
Add Obsidian plugin starter template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# obsidian-plugin
+# Obsidian Plugin
+
+This repository contains a starter template for developing an Obsidian plugin using TypeScript.
+
+## Development
+
+1. Install dependencies with `npm install`.
+2. Use `npm run dev` to build the plugin in watch mode.
+3. Run `npm run build` to create a production build in the `dist/` folder.
+
+The compiled plugin files (`manifest.json`, `main.js`, and `styles.css`) are placed in `dist/`. Copy this folder to your Obsidian vault's plugin directory to load the plugin.

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "sample-plugin",
+  "name": "Sample Plugin",
+  "version": "0.0.1",
+  "minAppVersion": "0.15.0",
+  "description": "A minimal starter plugin for Obsidian",
+  "author": "Your Name",
+  "authorUrl": "https://example.com",
+  "isDesktopOnly": false
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "sample-plugin",
+  "version": "0.0.1",
+  "description": "A minimal starter plugin for Obsidian",
+  "scripts": {
+    "dev": "rollup -c -w",
+    "build": "rollup -c"
+  },
+  "devDependencies": {
+    "@rollup/plugin-commonjs": "^25.0.0",
+    "@rollup/plugin-node-resolve": "^15.0.0",
+    "rollup": "^3.0.0",
+    "rollup-plugin-terser": "^7.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,20 @@
+import typescript from 'rollup-plugin-typescript2';
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import commonjs from '@rollup/plugin-commonjs';
+import { terser } from 'rollup-plugin-terser';
+
+export default {
+  input: 'src/main.ts',
+  output: {
+    dir: 'dist',
+    format: 'cjs',
+    sourcemap: false,
+  },
+  external: ['obsidian'],
+  plugins: [
+    typescript(),
+    nodeResolve({ browser: true }),
+    commonjs(),
+    terser()
+  ]
+};

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,0 +1,58 @@
+import { App, Plugin, PluginSettingTab, Setting } from 'obsidian';
+
+export interface SamplePluginSettings {
+  sampleSetting: string;
+}
+
+const DEFAULT_SETTINGS: SamplePluginSettings = {
+  sampleSetting: 'default'
+};
+
+export default class SamplePlugin extends Plugin {
+  settings: SamplePluginSettings;
+
+  async onload() {
+    console.log('Loading Sample Plugin');
+    await this.loadSettings();
+
+    this.addSettingTab(new SampleSettingTab(this.app, this));
+  }
+
+  onunload() {
+    console.log('Unloading Sample Plugin');
+  }
+
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+  }
+
+  async saveSettings() {
+    await this.saveData(this.settings);
+  }
+}
+
+class SampleSettingTab extends PluginSettingTab {
+  plugin: SamplePlugin;
+
+  constructor(app: App, plugin: SamplePlugin) {
+    super(app, plugin);
+    this.plugin = plugin;
+  }
+
+  display(): void {
+    const { containerEl } = this;
+
+    containerEl.empty();
+
+    new Setting(containerEl)
+      .setName('Sample Setting')
+      .setDesc('A simple example setting')
+      .addText(text => text
+        .setPlaceholder('Enter your setting')
+        .setValue(this.plugin.settings.sampleSetting)
+        .onChange(async (value) => {
+          this.plugin.settings.sampleSetting = value;
+          await this.plugin.saveSettings();
+        }));
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1 @@
+/* Add your plugin styles here */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "esnext",
+    "lib": ["dom", "es2017"],
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "noImplicitAny": false,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- create a starter Obsidian plugin using TypeScript
- add manifest, build config and plugin skeleton
- document how to build and use the plugin

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: rollup not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857363e08ec83239b0ff70fbd49cd4f